### PR TITLE
KSH-8 : Linear gradient background for the app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,14 +1,24 @@
-import { StatusBar } from 'expo-status-bar';
-import { Text, View } from 'react-native';
+import { StatusBar } from 'expo-status-bar'
+import { Text, View } from 'react-native'
+import { LinearGradient } from 'expo-linear-gradient'
 
 // custom imports
-import { styles } from './baseStyle';
+import { styles } from './baseStyle'
 
-export default function App() {
+export default function App () {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
-  );
+    <LinearGradient
+      colors={['rgba(133, 160, 255, 0.73)', 'transparent']}
+      style={styles.body}
+      start={{ x: 0.5, y: 1 }}
+      end={{ x: 0.5, y: 0 }}
+    >
+      <View>
+        <Text>Keepshift</Text>
+
+        {/* Status bar component below allows us to go full screen in the notch area */}
+        <StatusBar style='auto' />
+      </View>
+    </LinearGradient>
+  )
 }

--- a/baseStyle.tsx
+++ b/baseStyle.tsx
@@ -1,10 +1,10 @@
 import { StyleSheet } from 'react-native'
 
 export const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: '#fff',
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
-});
+  body: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#5F6FFF'
+  }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "expo": "~47.0.12",
+        "expo-linear-gradient": "^12.0.1",
         "expo-status-bar": "~1.4.2",
         "react": "18.1.0",
         "react-dom": "18.1.0",
@@ -6548,6 +6549,14 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-11.0.1.tgz",
       "integrity": "sha512-44ZjgLE4lnce2d40Pv8xsjMVc6R5GvgHOwZfkLYtGmgYG9TYrEJeEj5UfSeweXPL3pBFhXKfFU8xpGYMaHdP0A==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-12.0.1.tgz",
+      "integrity": "sha512-TMl/wBTVQOliL4S3DS5Aa3UFfVySr0mdJEHLG6kfBdMCLkr+tfLI2rGyJ+scS7xgMsvhTIaurhf1+Z0sL3aLCg==",
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "expo": "~47.0.12",
+    "expo-linear-gradient": "^12.0.1",
     "expo-status-bar": "~1.4.2",
     "react": "18.1.0",
     "react-dom": "18.1.0",


### PR DESCRIPTION
Linear - https://linear.app/oddhours/issue/KSH-8/homescreen-landing-page


Tests
- run `npm install` to get the `expo-linear-gradient` package installed on your local repo
- run `expo start` & verify on your device that the gradient looks good